### PR TITLE
Fix typo in right hand value of CONFIG_NOVA_NETWORK_PRIVIF in controller_answers.txt template.

### DIFF
--- a/conf/openstack/10_base_overrides.yml
+++ b/conf/openstack/10_base_overrides.yml
@@ -33,7 +33,7 @@ common:
       #db_pw: *packstack_pw
       #ks_pw: *packstack_pw
       pub_if: eth0
-      private_if: eth1
+      priv_if: eth1
       network:
         fixedrange: 192.168.32.0/24  # openstack-private network
         floatrange: 10.3.4.0/22      # Not used w/ neutron-based (default)

--- a/templates/autoinstall.d/data/openstack/controller_answers.txt
+++ b/templates/autoinstall.d/data/openstack/controller_answers.txt
@@ -207,7 +207,7 @@ CONFIG_NOVA_NETWORK_MANAGER=nova.network.manager.FlatDHCPManager
 CONFIG_NOVA_NETWORK_PUBIF={{ packstack.nova.pub_if|default('eth0') }}
 
 # Private interface for network manager on the Nova network server
-CONFIG_NOVA_NETWORK_PRIVIF={{ packstack.nova.pub_if|default('eth1') }}
+CONFIG_NOVA_NETWORK_PRIVIF={{ packstack.nova.priv_if|default('eth1') }}
 
 # IP Range for network manager
 CONFIG_NOVA_NETWORK_FIXEDRANGE={{ packstack.nova.network.fixedrange|default('192.168.32.0/22') }}


### PR DESCRIPTION
Prefer "priv_if" to "private_if" because the label for public interface is "pub_if", not "public_if".
Note that allinone_answers.txt also has CONFIG_NOVA_NETWORK_PRIVIF and uses "priv_if".
