### PR TITLE
satellite6: Fix wrong temporary file name for caching location id

### DIFF
--- a/templates/autoinstall.d/data/satellite6/Makefile.custom
+++ b/templates/autoinstall.d/data/satellite6/Makefile.custom
@@ -21,11 +21,11 @@ define create-locations =
 hammer --csv location list | grep -qE ',{{ loc }}$$' 2>/dev/null || \
 hammer location create --name '{{ loc }}'
 {%          if loop.first -%}
-hammer --output=yaml location info --name '{{ loc }}' | sed -nr "s/^Id: //p" > $(LOC_ID_FILE) && test -s $(LOC_ID_FILE).t && mv $(LOC_ID_FILE).t $(LOC_ID_FILE) || :
+hammer --output=yaml location info --name '{{ loc }}' | sed -nr "s/^Id: //p" > $(LOC_ID_FILE).t && test -s $(LOC_ID_FILE).t && mv $(LOC_ID_FILE).t $(LOC_ID_FILE) || :
 {%-         endif %}
 {%      endfor %}
 {%- else %}
-hammer --output=yaml location info --name '$(LOCATION_NAME)' | sed -nr "s/^Id: //p" > $(LOC_ID_FILE) && \
+hammer --output=yaml location info --name '$(LOCATION_NAME)' | sed -nr "s/^Id: //p" > $(LOC_ID_FILE).t && \
 test -s $(LOC_ID_FILE).t && mv $(LOC_ID_FILE).t $(LOC_ID_FILE);
 {%- endif %}
 endef


### PR DESCRIPTION
"location_id.txt" is used directly though "location_id.txt.t" should be
used as a temporary file name.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>