### PR TITLE
Introduce virtinst.clock for passing --clock to virt-install

### DIFF
--- a/templates/guest/vmbuild.sh
+++ b/templates/guest/vmbuild.sh
@@ -97,6 +97,7 @@ ${location_opts} \
 {%     endfor %} \
 {%     for nic in interfaces -%}
 --network {{ net_option(nic) }} \
-{%     endfor %}
+{%     endfor %} \
+{{     ' --clock %s' % virtinst.clock if virtinst.clock }} \
 {% endblock %}
 # vim:sw=4:ts=4:et:


### PR DESCRIPTION
Usage:

    guests:
      - name: satellite
	description: Red Hat Satellite 6 server

	disks: &satellite_disks
	  - pool: default
	    ...

	virtinst:
	  ram: 8192
	  ...
>>>	  clock: offset=localtime

Signed-off-by: Masatake YAMATO <yamato@redhat.com>