### PR TITLE
satellite6: add ipxe-bootimgs and pyOpenSSL as required packages

### DIFF
--- a/templates/autoinstall.d/data/satellite6/rhel-7.required_rpms.txt
+++ b/templates/autoinstall.d/data/satellite6/rhel-7.required_rpms.txt
@@ -26,6 +26,7 @@ httpcomponents-client
 httpcomponents-core
 httpd
 ipmitool
+ipxe-bootimgs
 jakarta-commons-httpclient
 jakarta-commons-io
 jakarta-commons-lang
@@ -59,6 +60,7 @@ policycoreutils-python
 postgresql
 postgresql-jdbc
 postgresql-server
+pyOpenSSL
 python-babel
 python-cherrypy
 python-imaging


### PR DESCRIPTION
These are needed when installing satellite-6.2.9 to RHEL 7.3.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>