### PR TITLE
satellite6: add lifecycle-environment to an activation-key only if its content view is "Default Organization View"

### DIFF
--- a/templates/autoinstall.d/data/satellite6/Makefile.custom
+++ b/templates/autoinstall.d/data/satellite6/Makefile.custom
@@ -108,7 +108,7 @@ grep ',{{ key.name }},' ~/.hammer/activation_keys_00.txt || \
 hammer activation-key create --organization-id `cat $<` \
 --name '{{ key.name }}' {{ '--description "%s"' % key.description if key.description }} \
 --content-view '{{ key.cv or "Default Organization View" }}' \
-{{ '--lifecycle-environment %s' % key.env|default('Library') }} \
+{{ '--lifecycle-environment %s' % key.env|default('Library') if key.cv is equalto 'Default Organization View' }} \
 {{ '--max-content-hosts %s' % key.max if key.max  }} && \
 {%         if key.hc -%}
 hammer activation-key add-host-collection --organization-id `cat $<` \


### PR DESCRIPTION
"make setup" is failed when creating activation-key with a
lifecycle-environment and a content-view.

This change limits to add a lifecycle-environment to
activation-key. Adding a lifecycle-environment is allowed only if the
content view is "Default Organization View".

To attach lifecycle-environment and content-view to an activation-key
at the same time, the content-view must be prompted to the
lifecycle-environment.  ("Default Organization View" is an exception.)

However, commands in CREATE_ACTIVATION_KEYS of Makefile.custom is
called early stage of deploying satellite6 server. So the promption is
not done yet. It may be possible to add commands for the promotion,
but I think this stage (make setup) is too early to do so.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>