### PR TITLE
satellite6: install libdb-cxx in kickstart stage

### DIFF
--- a/templates/autoinstall.d/data/satellite6/required_rpms.txt
+++ b/templates/autoinstall.d/data/satellite6/required_rpms.txt
@@ -42,3 +42,12 @@ squid
 syslinux
 tftp-server
 xinetd
+# satellite-6.2.12.iso includes libdb-cxx-5.3.21-19.
+# In the other hande, rhel-7.4 includes libdb-5.3.21-20.
+# If libdb-5.3.21-20 is not installed in the kick start stage,
+# satellite-installer tries to libdb-cxx-5.3.21-19 in the iso.
+# The version(-19) doesn't much with the version of libdb
+# package (libdb-5.3.21-20.el7.x86_64), which is installed
+# in the kick start stage implicitly. This mismatch makes
+# running satellite-installer failed.
+libdb-cxx


### PR DESCRIPTION
(Feel free to remove comment lines in required_rpms.txt if you want to keep the file simple.)

The combination of satellite-6.2.12 and rhel-7.4 requires
NEWER libdb-cxx.

Without isntalling libdb-cxx in kickstart stage, "make install"
report following error:

    Error: Package: libdb-cxx-5.3.21-19.el7.x86_64 (satellite-local)
	       Requires: libdb(x86-64) = 5.3.21-19.el7
	       Installed: libdb-5.3.21-20.el7.x86_64 (@anaconda/7.4)
		   libdb(x86-64) = 5.3.21-20.el7

satellite-6.2.12.iso includes libdb-cxx-5.3.21-19.  In the other
hande, rhel-7.4 includes libdb-5.3.21-20.  If libdb-5.3.21-20 is not
installed in the kick start stage, satellite-installer tries to
libdb-cxx-5.3.21-19 from the iso.  The version(-19) of libdb-cxx
doesn't much with the version of libdb package
(libdb-5.3.21-20.el7.x86_64), which is installed in the kick start
stage implicitly. This mismatch makes running satellite-installer
failed.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>