### PR TITLE
satellite6: make ORGANIZATION name customizable

### DIFF
--- a/templates/autoinstall.d/data/satellite/6/config.sh
+++ b/templates/autoinstall.d/data/satellite/6/config.sh
@@ -72,7 +72,7 @@ SATELLITE_INSTALLER_OPTIONS="
 {% endif -%}
 "
 
-ORG_NAME="Default Organization"
+ORG_NAME={{ satellite.organization|default("Default Organization") }}
 ORG_LABEL=${ORG_NAME/ /_}
 LOC_NAME="Default Location"
 


### PR DESCRIPTION
ORGANIZATION is not custumizable in shell script based setup tools
though it is possible in Makefile based setup tools.
It is regression.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>