### PR TITLE
network: allow to define extra dns entries

### DIFF
--- a/templates/config/network.j2
+++ b/templates/config/network.j2
@@ -5,6 +5,12 @@ domain: {{ domain }}
 gateway: {{ gateway }}
 netmask: {{ netmask }}
 network: {{ network }}
+{% if dns is defined -%}
+dns:
+{% for d in dns %}  - ip: {{ d.ip }}
+    hostname: {{ d.hostname }}
+{% endfor -%}
+{%- endif -%}
 {% if dhcp is defined and dhcp.start is defined -%}
 dhcp:
   start: {{ dhcp.start }}

--- a/templates/host/networks/network.xml
+++ b/templates/host/networks/network.xml
@@ -10,6 +10,11 @@
     {%   for h in hosts|sort(attribute="ip") if h.fqdn is defined or h.host is defined -%}
     <host ip='{{ h.ip }}'><hostname>{{ h.fqdn if h.fqdn is defined else '%s.%s' % (h.host, domain) }}</hostname></host>
 {%       endfor %}
+{%- if dns is defined %}
+    {%   for d in dns -%}
+    <host ip='{{ d.ip }}'><hostname>{{ d.hostname }}</hostname></host>
+    {%       endfor %}
+{%    endif %}
   </dns>
 {%- endif %}
 {%  if gateway is defined and gateway -%}


### PR DESCRIPTION
With this change, a user can add an extra
dns entry to dnsmasq network with following
notation:

    network_0: &network_0
      name: &network_name_0 mynetwork
      mode: nat
      bridge: mybr
      domain: &domain_0 example.com
      gateway: &gateway_0 192.168.0.1
      netmask: &netmask_0 255.255.255.0
      network: 192.168.0.0/24
      dns:
	- ip: 192.168.0.2
	  hostname: webproxy.example.com
      ...

Signed-off-by: Masatake YAMATO <yamato@redhat.com>