### PR TITLE
enhancement: limit the length of fqdn

### DIFF
--- a/miniascape/config.py
+++ b/miniascape/config.py
@@ -90,6 +90,9 @@ def _guest_add_missings(conf):
         if "fqdn" not in conf:
             conf["fqdn"] = "{hostname}.{domain}".format(**conf)
 
+    assert len(conf["fqdn"]) <= 64, \
+        "Up to 64 chars are allowed as fqdn: " + conf["fqdn"]
+
     # TODO: Automatic (static) dhcp address assignment:
     # if conf.get("ip", None) == "auto":
     #    ...


### PR DESCRIPTION
As discussed in
https://stackoverflow.com/questions/8724954/what-is-the-maximum-number-of-characters-for-a-host-name-in-unix,
fqdn(common name) used in TLS/SSL certificates should not exceed 64
bytes. It may be helpful that miniascape rejects too long fqdn
specification in yml files.

This change is not perfect; more asserts should be put around.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>