### PR TITLE
allow to rename nic

### DIFF
--- a/templates/autoinstall.d/snippets/post.generate_etc_sysconfig_network_files
+++ b/templates/autoinstall.d/snippets/post.generate_etc_sysconfig_network_files
@@ -22,6 +22,12 @@ f=$confdir/ifcfg-{{ ni.device }}
 bf=/root/setup/$f.save
 test -f $bf || cp $f $bf
 hwaddr_line=$(grep -E ^HWADDR $f)
+if [ -z "${hwaddr_line}" ]; then
+  hwaddr_line=$(ip -o link show dev {{ ni.device }} | sed -e 's@.*link/ether \([0-9a-f:]*\) .*@\1@')
+  if [ -n "${hwaddr_line}" ]; then
+    hwaddr_line="HWADDR=${hwaddr_line}"
+  fi
+fi
 cat << EOF > $f
 NAME={{ ni.altname if ni.altname else ni.device }}
 DEVICE={{ ni.altname if ni.altname else ni.device }}

--- a/templates/autoinstall.d/snippets/post.generate_etc_sysconfig_network_files
+++ b/templates/autoinstall.d/snippets/post.generate_etc_sysconfig_network_files
@@ -23,8 +23,8 @@ bf=/root/setup/$f.save
 test -f $bf || cp $f $bf
 hwaddr_line=$(grep -E ^HWADDR $f)
 cat << EOF > $f
-NAME={{ ni.device }}
-DEVICE={{ ni.device }}
+NAME={{ ni.altname if ni.altname else ni.device }}
+DEVICE={{ ni.altname if ni.altname else ni.device }}
 ${hwaddr_line}
 TYPE={{ ni.type|default('Ethernet') }}
 IPADDR={{ ni.ip }} 


### PR DESCRIPTION
See the commits log.
This is needed to renamed eth0 to ensX.
I'm not sure these changes are the best way. However, they works.