### PR TITLE
fix: expand template paths even when using wildcard in setup_data

### DIFF
--- a/miniascape/guest.py
+++ b/miniascape/guest.py
@@ -53,7 +53,7 @@ def _guests_workdir(topdir, subdir=G.M_GUESTS_CONF_SUBDIR):
 
 
 def _find_templates_from_glob_path(tmpl, gtmpldirs):
-    """Find templates from globa path such as 'data/*/*.sh".
+    """Find templates from global path such as 'data/*/*.sh".
 
     :return: A generator yields (template_rel_path, template_dir)
     """

--- a/miniascape/guest.py
+++ b/miniascape/guest.py
@@ -118,7 +118,8 @@ def arrange_setup_data(gtmpldirs, config, gworkdir, glob_marker='*'):
             if glob_marker in src:
                 for src_, sdir in _find_templates_from_glob_path(src,
                                                                  gtmpldirs):
-                    _render_template(src_, config, gworkdir, [sdir])
+                    tpaths = _template_paths(src_, [sdir])
+                    _render_template(src_, config, gworkdir, tpaths)
             else:
                 dst = t.get("dst", src)
                 tpaths = _template_paths(src, gtmpldirs)


### PR DESCRIPTION
It seems that template paths are not expanded correctly when using
wildcard (*) in a src field in setup_data.

I have to put the complete path for a tepmlate file with following
prompt "Please enter an absolute or relative path starting from '.' of
missing template file,
data/satellite/6/checks.d/10_20_num_processors.sh : " if following
lines are in a yml file:

    setup_data:
      - src: data/satellite/6/checks.d/*.sh
        dst: checks.sh

Signed-off-by: Masatake YAMATO <yamato@redhat.com>